### PR TITLE
fix UnicodeDecodeError when use multibyte OS such as Japanease

### DIFF
--- a/fgaddressestocsv.py
+++ b/fgaddressestocsv.py
@@ -43,6 +43,7 @@ main_grp.add_option('-o', '--output-file', help='Output csv file (default ./addr
 main_grp.add_option('-s', '--skip-header', help='Do not print the csv header', action='store_true', default=False)
 main_grp.add_option('-n', '--newline', help='Insert a newline between each group for better readability', action='store_true', default=False)
 main_grp.add_option('-d', '--delimiter', help='CSV delimiter (default ";")', default=';')
+main_grp.add_option('-e', '--encoding', help='input file encoding (default "utf8")', default='utf8')
 parser.option_groups.extend([main_grp])
 
 # Python 2 and 3 compatibility
@@ -87,7 +88,7 @@ def parse(options):
     
     order_keys = []
     
-    with open(options.input_file, mode=fd_read_options) as fd_input:
+    with open(options.input_file, mode=fd_read_options, encoding=options.encoding) as fd_input:
         for line in fd_input:
             line = line.strip()
             

--- a/fggroupstocsv.py
+++ b/fggroupstocsv.py
@@ -43,6 +43,7 @@ main_grp.add_option('-o', '--output-file', help='Output csv file (default ./grou
 main_grp.add_option('-s', '--skip-header', help='Do not print the csv header', action='store_true', default=False)
 main_grp.add_option('-n', '--newline', help='Insert a newline between each group for better readability', action='store_true', default=False)
 main_grp.add_option('-d', '--delimiter', help='CSV delimiter (default ";")', default=';')
+main_grp.add_option('-e', '--encoding', help='input file encoding (default "utf8")', default='utf8')
 parser.option_groups.extend([main_grp])
 
 # Python 2 and 3 compatibility
@@ -87,7 +88,7 @@ def parse(options):
     
     order_keys = []
     
-    with open(options.input_file, mode=fd_read_options) as fd_input:
+    with open(options.input_file, mode=fd_read_options, encoding=options.encoding) as fd_input:
         for line in fd_input:
             line = line.strip()
             

--- a/fgpoliciestocsv.py
+++ b/fgpoliciestocsv.py
@@ -43,6 +43,7 @@ main_grp.add_option('-o', '--output-file', help='Output csv file (default ./poli
 main_grp.add_option('-s', '--skip-header', help='Do not print the csv header', action='store_true', default=False)
 main_grp.add_option('-n', '--newline', help='Insert a newline between each policy for better readability', action='store_true', default=False)
 main_grp.add_option('-d', '--delimiter', help='CSV delimiter (default ";")', default=';')
+main_grp.add_option('-e', '--encoding', help='input file encoding (default "utf8")', default='utf8')
 parser.option_groups.extend([main_grp])
 
 # Python 2 and 3 compatibility
@@ -90,7 +91,7 @@ def parse(options):
     
     order_keys = []
     
-    with open(options.input_file, mode=fd_read_options) as fd_input:
+    with open(options.input_file, mode=fd_read_options, encoding=options.encoding) as fd_input:
         for line in fd_input:
             line = line.strip()
             

--- a/fgservicestocsv.py
+++ b/fgservicestocsv.py
@@ -43,6 +43,7 @@ main_grp.add_option('-o', '--output-file', help='Output csv file (default ./serv
 main_grp.add_option('-s', '--skip-header', help='Do not print the csv header', action='store_true', default=False)
 main_grp.add_option('-n', '--newline', help='Insert a newline between each group for better readability', action='store_true', default=False)
 main_grp.add_option('-d', '--delimiter', help='CSV delimiter (default ";")', default=';')
+main_grp.add_option('-e', '--encoding', help='input file encoding (default "utf8")', default='utf8')
 parser.option_groups.extend([main_grp])
 
 # Python 2 and 3 compatibility
@@ -87,7 +88,7 @@ def parse(options):
     
     order_keys = []
     
-    with open(options.input_file, mode=fd_read_options) as fd_input:
+    with open(options.input_file, mode=fd_read_options, encoding=options.encoding) as fd_input:
         for line in fd_input:
             line = line.strip()
             


### PR DESCRIPTION
I got UnicodeDecodeError on Japanese Windows OS with miniconda.

   File "fgpoliciestocsv.py", line 94, in parse
     for line in fd_input:
    UnicodeDecodeError: 'cp932' codec can't decode byte 0x83 in position 563: illegal multibyte sequence

could you marge this fix for multilingual environment.
regard
